### PR TITLE
remove add listener during native import

### DIFF
--- a/src/Background/background.js
+++ b/src/Background/background.js
@@ -118,6 +118,17 @@ chrome.bookmarks.onMoved.addListener(async function(id, info){
     })
 })
 
+chrome.bookmarks.onImportBegan.addListener(async function(){
+  chrome.bookmarks.onCreated.removeListener(sendBookmarkToElysian);
+})
+
+chrome.bookmarks.onImportEnded.addListener(async function(){
+  chrome.bookmarks.onCreated.addListener(sendBookmarkToElysian);
+  // console.log("Exporting")
+  // TODO Call the export function here
+  // console.log("exported")
+})
+
 chrome.runtime.onMessage.addListener(async function(message) {
   if (message.content === "export_to_elysian"){
       chrome.bookmarks.getTree(function(bookmarkTreeNodes) {


### PR DESCRIPTION
Closes #6
Adds logic to remove add listener when browser's native import is triggered
